### PR TITLE
Problem API response extended by HTTP method and possible stacktrace

### DIFF
--- a/integration-test/src/test/java/solutions/cloudstark/quarkus/zalando/problem/runtime/TestResourceIT.java
+++ b/integration-test/src/test/java/solutions/cloudstark/quarkus/zalando/problem/runtime/TestResourceIT.java
@@ -51,7 +51,8 @@ public class TestResourceIT {
         .body("status", is(INTERNAL_SERVER_ERROR.getStatusCode()))
         .body("http_method", is("GET"))
         .body("instance", is(path))
-        .body("detail", is("java.lang.ArithmeticException: / by zero"));
+        .body("detail", is("java.lang.ArithmeticException: / by zero"))
+        .body("stacktrace.size()", is(51));
   }
 
   @Test
@@ -84,7 +85,8 @@ public class TestResourceIT {
         .body("status", is(INTERNAL_SERVER_ERROR.getStatusCode()))
         .body("http_method", is("GET"))
         .body("instance", is(path))
-        .body("detail", endsWith(TestResource.RUNTIME_EXCEPTION_MESSAGE));
+        .body("detail", endsWith(TestResource.RUNTIME_EXCEPTION_MESSAGE))
+        .body("stacktrace.size()", is(41));
   }
 
   @Test

--- a/integration-test/src/test/java/solutions/cloudstark/quarkus/zalando/problem/runtime/TestResourceIT.java
+++ b/integration-test/src/test/java/solutions/cloudstark/quarkus/zalando/problem/runtime/TestResourceIT.java
@@ -29,6 +29,7 @@ public class TestResourceIT {
         .statusCode(NOT_FOUND.getStatusCode())
         .body("title", startsWith("RESTEASY003210"))
         .body("status", is(NOT_FOUND.getStatusCode()))
+        .body("http_method", is("GET"))
         .body("instance", is(path))
         .body("detail", startsWith("javax.ws.rs.NotFoundException"));
   }
@@ -48,6 +49,7 @@ public class TestResourceIT {
         .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
         .body("title", is("/ by zero"))
         .body("status", is(INTERNAL_SERVER_ERROR.getStatusCode()))
+        .body("http_method", is("GET"))
         .body("instance", is(path))
         .body("detail", is("java.lang.ArithmeticException: / by zero"));
   }
@@ -62,6 +64,7 @@ public class TestResourceIT {
         .statusCode(BAD_REQUEST.getStatusCode())
         .body("title", is("Constraint Violation"))
         .body("status", is(BAD_REQUEST.getStatusCode()))
+        .body("http_method", is(nullValue()))
         .body("instance", is(nullValue()))
         .body("detail", is(nullValue()))
         .body("violations[0].size()", is(2))
@@ -79,6 +82,7 @@ public class TestResourceIT {
         .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
         .body("title", is(TestResource.RUNTIME_EXCEPTION_MESSAGE))
         .body("status", is(INTERNAL_SERVER_ERROR.getStatusCode()))
+        .body("http_method", is("GET"))
         .body("instance", is(path))
         .body("detail", endsWith(TestResource.RUNTIME_EXCEPTION_MESSAGE));
   }
@@ -92,6 +96,7 @@ public class TestResourceIT {
         .statusCode(BAD_REQUEST.getStatusCode())
         .body("title", is(TestResource.STRANGE_PROBLEM_TITLE))
         .body("status", is(BAD_REQUEST.getStatusCode()))
+        .body("http_method", is(nullValue()))
         .body("instance", is(nullValue()))
         .body("detail", is(nullValue()));
   }
@@ -106,6 +111,7 @@ public class TestResourceIT {
         .statusCode(UNAUTHORIZED.getStatusCode())
         .body("title", is(nullValue()))
         .body("status", is(UNAUTHORIZED.getStatusCode()))
+        .body("http_method", is("GET"))
         .body("instance", is(path))
         .body("detail", is("io.quarkus.security.UnauthorizedException"));
   }
@@ -123,6 +129,7 @@ public class TestResourceIT {
         .statusCode(FORBIDDEN.getStatusCode())
         .body("title", is(nullValue()))
         .body("status", is(FORBIDDEN.getStatusCode()))
+        .body("http_method", is("GET"))
         .body("instance", is(path))
         .body("detail", is("io.quarkus.security.ForbiddenException"));
   }

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/ForbiddenExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/ForbiddenExceptionMapper.java
@@ -16,7 +16,10 @@
 
 package solutions.cloudstark.quarkus.zalando.problem.runtime;
 
+import static solutions.cloudstark.quarkus.zalando.problem.runtime.RestExceptionMapper.HTTP_METHOD_KEY;
+
 import io.quarkus.security.ForbiddenException;
+import io.vertx.core.http.HttpServerRequest;
 import java.net.URI;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
@@ -33,6 +36,8 @@ import org.zalando.problem.ThrowableProblem;
 @Priority(Priorities.USER)
 public class ForbiddenExceptionMapper implements ExceptionMapper<ForbiddenException> {
 
+  @Context HttpServerRequest request;
+
   @Context UriInfo uriInfo;
 
   @Override
@@ -42,6 +47,7 @@ public class ForbiddenExceptionMapper implements ExceptionMapper<ForbiddenExcept
             .withStatus(Status.FORBIDDEN)
             .withTitle(exception.getMessage())
             .withDetail(exception.toString())
+            .with(HTTP_METHOD_KEY, request.rawMethod())
             .withInstance(URI.create(uriInfo.getPath()))
             .build();
     return Response.status(throwableProblem.getStatus().getStatusCode())

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/NotFoundExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/NotFoundExceptionMapper.java
@@ -16,6 +16,9 @@
 
 package solutions.cloudstark.quarkus.zalando.problem.runtime;
 
+import static solutions.cloudstark.quarkus.zalando.problem.runtime.RestExceptionMapper.HTTP_METHOD_KEY;
+
+import io.vertx.core.http.HttpServerRequest;
 import java.net.URI;
 import javax.annotation.Priority;
 import javax.ws.rs.NotFoundException;
@@ -33,6 +36,8 @@ import org.zalando.problem.ThrowableProblem;
 @Priority(Priorities.USER)
 public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
 
+  @Context HttpServerRequest request;
+
   @Context UriInfo uriInfo;
 
   @Override
@@ -42,6 +47,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
             .withStatus(Status.NOT_FOUND)
             .withTitle(exception.getMessage())
             .withDetail(exception.toString())
+            .with(HTTP_METHOD_KEY, request.rawMethod())
             .withInstance(URI.create(uriInfo.getPath()))
             .build();
     return Response.status(throwableProblem.getStatus().getStatusCode())

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/RestExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/RestExceptionMapper.java
@@ -16,6 +16,7 @@
 
 package solutions.cloudstark.quarkus.zalando.problem.runtime;
 
+import io.vertx.core.http.HttpServerRequest;
 import java.net.URI;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -29,6 +30,10 @@ import org.zalando.problem.ThrowableProblem;
 @Provider
 public class RestExceptionMapper implements ExceptionMapper<Throwable> {
 
+  static final String HTTP_METHOD_KEY = "http_method";
+
+  @Context HttpServerRequest request;
+
   @Context UriInfo uriInfo;
 
   @Override
@@ -38,6 +43,7 @@ public class RestExceptionMapper implements ExceptionMapper<Throwable> {
             .withStatus(Status.INTERNAL_SERVER_ERROR)
             .withTitle(throwable.getMessage())
             .withDetail(throwable.toString())
+            .with(HTTP_METHOD_KEY, request.rawMethod())
             .withInstance(URI.create(uriInfo.getPath()))
             .build();
 

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/UnauthorizedExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/zalando/problem/runtime/UnauthorizedExceptionMapper.java
@@ -16,7 +16,10 @@
 
 package solutions.cloudstark.quarkus.zalando.problem.runtime;
 
+import static solutions.cloudstark.quarkus.zalando.problem.runtime.RestExceptionMapper.HTTP_METHOD_KEY;
+
 import io.quarkus.security.UnauthorizedException;
+import io.vertx.core.http.HttpServerRequest;
 import java.net.URI;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
@@ -33,6 +36,8 @@ import org.zalando.problem.ThrowableProblem;
 @Priority(Priorities.USER)
 public class UnauthorizedExceptionMapper implements ExceptionMapper<UnauthorizedException> {
 
+  @Context HttpServerRequest request;
+
   @Context UriInfo uriInfo;
 
   @Override
@@ -42,6 +47,7 @@ public class UnauthorizedExceptionMapper implements ExceptionMapper<Unauthorized
             .withStatus(Status.UNAUTHORIZED)
             .withTitle(exception.getMessage())
             .withDetail(exception.toString())
+            .with(HTTP_METHOD_KEY, request.rawMethod())
             .withInstance(URI.create(uriInfo.getPath()))
             .build();
     return Response.status(throwableProblem.getStatus().getStatusCode())


### PR DESCRIPTION
1. Added **http_method** as part of a "problem" API response. I think, if "instance" is given (which contains the called path), the method should be part of the response, too.

```json
{
"status":404,
"title":"RESTEASY003210: Could not find resource for full path: http://localhost:8080/notpresent",
"detail":"javax.ws.rs.NotFoundException: RESTEASY003210: Could not find resource for full path: http://localhost:8080/notpresent",
"instance":"/notpresent",
"http_method":"GET"
}
```
2. If Quarkus is launched in dev or test mode¹, and an unexpected exception is represented as a "problem", the **stacktrace** of the exception is attached to the "problem" API response, too.
In this example, the stacktrace is reduced to the last two elements.
```json
{
  "status": 500,
  "detail": "java.lang.reflect.UndeclaredThrowableException",
  "instance": "/somepath",
  "http_method": "GET",
  "stacktrace": [
    {
      "className": "java.lang.Thread",
      "fileName": "Thread.java",
      "lineNumber": 834,
      "methodName": "run",
      "moduleName": "java.base",
      "moduleVersion": "11.0.6",
      "nativeMethod": false
    },
    {
      "classLoaderName": "app",
      "className": "org.jboss.threads.JBossThread",
      "fileName": "JBossThread.java",
      "lineNumber": 479,
      "methodName": "run",
      "nativeMethod": false
    }
  ]
}
```

¹ https://quarkus.io/guides/lifecycle#launch-modes